### PR TITLE
remove ts compile to avoid errors from node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Queue Consumer for Metric Monitoring",
   "main": "build/lib/orchestrator.js",
   "scripts": {
-    "compile": "rm -rf ./build && tsc",
+    "compile": "rm -rf ./build",
     "prepare": "npm run compile",
     "test": "npm run compile && nyc --reporter=html --reporter=json-summary --reporter=text-summary --exit-on-error=true mocha --timeout 30000 --recursive ./build/test"
   },


### PR DESCRIPTION
Recently, typescript errors pop-up out of nowhere:
```
npm ERR! > metric-monitoring@1.0.0 prepare
npm ERR! > npm run compile
npm ERR! 
npm ERR! 
npm ERR! > metric-monitoring@1.0.0 compile
npm ERR! > rm -rf ./build && tsc
npm ERR! 
npm ERR! node_modules/@types/node/child_process.d.ts(309,9): error TS1165: A computed property name in an ambient context must refer to an expression whose type is a literal type or a 'unique symbol' type.
npm ERR! node_modules/@types/node/child_process.d.ts(309,17): error TS2339: Property 'dispose' does not exist on type 'SymbolConstructor'.
npm ERR! node_modules/@types/node/dgram.d.ts(594,9): error TS1165: A computed property name in an ambient context must refer to an expression whose type is a literal type or a 'unique symbol' type.
<...>
npm ERR! node_modules/@types/node/worker_threads.d.ts(496,9): error TS1165: A computed property name in an ambient context must refer to an expression whose type is a literal type or a 'unique symbol' type.
npm ERR! node_modules/@types/node/worker_threads.d.ts(496,17): error TS2339: Property 'asyncDispose' does not exist on type 'SymbolConstructor'.
```

All errors resulting from `d.ts` files in node_modules dirs, so can be safely ignored.
Now `npm install` works fine:
```
doannathanael@IMF-Eng-DoanNathanael:~/dev/metric-monitoring$ npm i

> metric-monitoring@1.0.0 prepare
> npm run compile


> metric-monitoring@1.0.0 compile
> rm -rf ./build


up to date, audited 447 packages in 1s
```